### PR TITLE
appengine.Context is now context.Context

### DIFF
--- a/google/appengine.go
+++ b/google/appengine.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/rasa/oauth2-fork-b3f9a68"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/log"
 
 	"appengine"
 	"appengine/memcache"
@@ -42,7 +44,7 @@ func init() {
 }
 
 // AppEngineContext requires an App Engine request context.
-func AppEngineContext(ctx appengine.Context) oauth2.Option {
+func AppEngineContext(ctx context.Context) oauth2.Option {
 	return func(opts *oauth2.Options) error {
 		opts.TokenFetcherFunc = makeAppEngineTokenFetcher(ctx, opts)
 		opts.Client = &http.Client{
@@ -55,7 +57,7 @@ func AppEngineContext(ctx appengine.Context) oauth2.Option {
 // FetchToken fetches a new access token for the provided scopes.
 // Tokens are cached locally and also with Memcache so that the app can scale
 // without hitting quota limits by calling appengine.AccessToken too frequently.
-func makeAppEngineTokenFetcher(ctx appengine.Context, opts *oauth2.Options) func(*oauth2.Token) (*oauth2.Token, error) {
+func makeAppEngineTokenFetcher(ctx context.Context, opts *oauth2.Options) func(*oauth2.Token) (*oauth2.Token, error) {
 	return func(existing *oauth2.Token) (*oauth2.Token, error) {
 		mu.Lock()
 		defer mu.Unlock()
@@ -91,7 +93,7 @@ func makeAppEngineTokenFetcher(ctx appengine.Context, opts *oauth2.Options) func
 			Object:     *t,
 			Expiration: expiry.Sub(now),
 		}); err != nil {
-			ctx.Errorf("unexpected memcache.Set error: %v", err)
+			log.Errorf(ctx, "unexpected memcache.Set error: %v", err)
 		}
 		return t, nil
 	}
@@ -100,15 +102,15 @@ func makeAppEngineTokenFetcher(ctx appengine.Context, opts *oauth2.Options) func
 // aeMemcache wraps the needed Memcache functionality to make it easy to mock
 type aeMemcache struct{}
 
-func (m *aeMemcache) Get(c appengine.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
+func (m *aeMemcache) Get(c context.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
 	return memcache.Gob.Get(c, key, tok)
 }
 
-func (m *aeMemcache) Set(c appengine.Context, item *memcache.Item) error {
+func (m *aeMemcache) Set(c context.Context, item *memcache.Item) error {
 	return memcache.Gob.Set(c, item)
 }
 
 type memcacher interface {
-	Get(c appengine.Context, key string, tok *oauth2.Token) (*memcache.Item, error)
-	Set(c appengine.Context, item *memcache.Item) error
+	Get(c context.Context, key string, tok *oauth2.Token) (*memcache.Item, error)
+	Set(c context.Context, item *memcache.Item) error
 }

--- a/google/appengine_test.go
+++ b/google/appengine_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	"github.com/rasa/oauth2-fork-b3f9a68"
 
 	"appengine"
@@ -28,7 +29,7 @@ type mockMemcache struct {
 	getCount, setCount int
 }
 
-func (m *mockMemcache) Get(c appengine.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
+func (m *mockMemcache) Get(c context.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.getCount++
@@ -40,7 +41,7 @@ func (m *mockMemcache) Get(c appengine.Context, key string, tok *oauth2.Token) (
 	return nil, nil // memcache.Item is ignored anyway - return nil
 }
 
-func (m *mockMemcache) Set(c appengine.Context, item *memcache.Item) error {
+func (m *mockMemcache) Set(c context.Context, item *memcache.Item) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.setCount++
@@ -54,7 +55,7 @@ func (m *mockMemcache) Set(c appengine.Context, item *memcache.Item) error {
 
 var accessTokenCount = 0
 
-func mockAccessToken(c appengine.Context, scopes ...string) (token string, expiry time.Time, err error) {
+func mockAccessToken(c context.Context, scopes ...string) (token string, expiry time.Time, err error) {
 	accessTokenCount++
 	return "mytoken", time.Now(), nil
 }

--- a/google/appenginevm_test.go
+++ b/google/appenginevm_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/rasa/oauth2-fork-b3f9a68"
+	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/memcache"
 )
@@ -27,7 +28,7 @@ type mockMemcache struct {
 	getCount, setCount int
 }
 
-func (m *mockMemcache) Get(c appengine.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
+func (m *mockMemcache) Get(c context.Context, key string, tok *oauth2.Token) (*memcache.Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.getCount++
@@ -39,7 +40,7 @@ func (m *mockMemcache) Get(c appengine.Context, key string, tok *oauth2.Token) (
 	return nil, nil // memcache.Item is ignored anyway - return nil
 }
 
-func (m *mockMemcache) Set(c appengine.Context, item *memcache.Item) error {
+func (m *mockMemcache) Set(c context.Context, item *memcache.Item) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.setCount++
@@ -53,7 +54,7 @@ func (m *mockMemcache) Set(c appengine.Context, item *memcache.Item) error {
 
 var accessTokenCount = 0
 
-func mockAccessToken(c appengine.Context, scopes ...string) (token string, expiry time.Time, err error) {
+func mockAccessToken(c context.Context, scopes ...string) (token string, expiry time.Time, err error) {
 	accessTokenCount++
 	return "mytoken", time.Now(), nil
 }


### PR DESCRIPTION
minimal changes to get changed tree of Context that affect oauth2 fork
working. Fixed the tests as well.

Signed-off-by: Prasanna Santhanam tsp@qubole.com
